### PR TITLE
Failure and Success Events

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/IFTTTBuildNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/IFTTTBuildNotifier/config.jelly
@@ -2,6 +2,12 @@
     <f:entry title="${%Event Name}" field="eventName" help="/plugin/ifttt-build-notifier/help-eventName.html">
           <f:textbox/>
         </f:entry>
+    <f:entry title="${%Success Event Name}" field="successEventName" help="/plugin/ifttt-build-notifier/help-eventName.html">
+          <f:textbox/>
+        </f:entry>        
+    <f:entry title="${%Failure Event Name}" field="failureEventName" help="/plugin/ifttt-build-notifier/help-eventName.html">
+          <f:textbox/>
+        </f:entry>
     <f:entry title="${%Key}" field="key" help="/plugin/ifttt-build-notifier/help-key.html">
       <f:password/>
     </f:entry>


### PR DESCRIPTION
Created additional events to call specifically for build failure and a
separate event for success.  The end result is the user will have 3 events they can call into IFTTT maker Channel  "Eventname" that is called always, "Success Event" called only on a successful build, and "Failure Event" for when a build fails.  This provides additional flexibility, to have the actions based on the result of the build.
